### PR TITLE
Add min python version

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,10 +16,10 @@ build:
 
 requirements:
   host:
-    - python
+    - python >=3.6
     - pip
   run:
-    - python
+    - python >=3.6
 
 test:
   imports:


### PR DESCRIPTION
conda-forge doesn't support python 2, so not including here